### PR TITLE
Implement perform_get_address_size to fix "Not Implemented" errors

### DIFF
--- a/generic_binary.py
+++ b/generic_binary.py
@@ -126,6 +126,9 @@ class GenericBinary(BinaryView):
     def is_valid_for_data(cls, data):
         return data.read(0, 4) == cls.MAGIC
 
+    def perform_get_address_size(self):
+        return self.arch.address_size
+
     def page_align_up(self, value):
         return (value + 0xfff) // 0x1000 * 0x1000
     


### PR DESCRIPTION
Hi, while loading multiple Switch games, i got alot of NotImplementedError coming from  perform_get_address_size
So i implemented the function which stop the error spam.
Tested on Binary Ninja 3.5.4526